### PR TITLE
Add secret's key as a label

### DIFF
--- a/src/checkers/periodicAwsChecker.go
+++ b/src/checkers/periodicAwsChecker.go
@@ -66,7 +66,7 @@ func (p *PeriodicAwsChecker) StartChecking() {
 			for key, value := range secretMap {
 				if strings.Contains(key, ".pem") {
 					fmt.Println("# [INFO] Exporting metrics from ", key)
-					err := p.exporter.ExportMetrics(value.(string), secretName)
+					err := p.exporter.ExportMetrics(value.(string), secretName, key)
 					if err != nil {
 						metrics.ErrorTotal.Inc()
 						fmt.Errorf("Error exporting certificate metrics")

--- a/src/exporters/awsExporter.go
+++ b/src/exporters/awsExporter.go
@@ -9,14 +9,14 @@ type AwsExporter struct {
 }
 
 // ExportMetrics exports the provided PEM file
-func (c *AwsExporter) ExportMetrics(file, secretName string) error {
+func (c *AwsExporter) ExportMetrics(file, secretName, key string) error {
 	metricCollection, err := secondsToExpiryFromCertAsBase64String(file)
 	if err != nil {
 		return err
 	}
 
 	for _, metric := range metricCollection {
-		metrics.AwsCertExpirySeconds.WithLabelValues(secretName, file, metric.issuer, metric.cn).Set(metric.durationUntilExpiry)
+		metrics.AwsCertExpirySeconds.WithLabelValues(secretName, key, file, metric.issuer, metric.cn).Set(metric.durationUntilExpiry)
 	}
 
 	return nil

--- a/src/metrics/metrics.go
+++ b/src/metrics/metrics.go
@@ -83,7 +83,7 @@ var (
 			Name:      "cert_expires_in_seconds",
 			Help:      "Number of seconds til the cert expires.",
 		},
-		[]string{"secretName","file", "issuer", "cn"},
+		[]string{"secretName", "key", "file", "issuer", "cn"},
 	)
 )
 


### PR DESCRIPTION
I think it is important to have the name of the key as a label. This is the best way to find that particular certificate inside a secret,